### PR TITLE
Add search-based favorites with folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This project is a simple client-side crypto tracking website built only with HTM
 
 ## Getting Started
 
-Open `login.html` in a browser to create an account or login. After authentication you will be redirected to `index.html` where you can add favourite coins and load different modules.
+Open `login.html` in a browser to create an account or login. After authentication you will be redirected to `index.html` where you can search for coins, organise favourites into folders and load different modules.
 
 All data is stored in `localStorage` so no server is required.

--- a/index.html
+++ b/index.html
@@ -18,9 +18,11 @@
     <div class="container">
         <aside class="favorites">
             <h2>Favorites</h2>
-            <div id="favorite-list"></div>
-            <input type="text" id="add-favorite-input" placeholder="Add crypto id (e.g. bitcoin)">
-            <button onclick="addFavorite()">Add</button>
+            <input type="text" id="favorite-search-input" placeholder="Search tokens...">
+            <div id="search-results"></div>
+            <div id="favorite-folders"></div>
+            <input type="text" id="folder-name-input" placeholder="New folder name">
+            <button onclick="addFolder()">Add Folder</button>
         </aside>
 
         <main class="modules">

--- a/style.css
+++ b/style.css
@@ -71,3 +71,60 @@ header {
     margin-top: 10px;
     font-size: 0.9em;
 }
+
+/* Favorites */
+#favorite-search-input {
+    width: 90%;
+    padding: 5px;
+    margin-bottom: 5px;
+}
+
+#search-results {
+    max-height: 150px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+}
+
+.search-result-item {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+    cursor: pointer;
+}
+
+.search-result-item img {
+    width: 20px;
+    height: 20px;
+    margin-right: 5px;
+}
+
+.folder {
+    margin-bottom: 10px;
+}
+
+.folder-title {
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.favorite-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.favorite-item img {
+    width: 20px;
+    height: 20px;
+    margin-right: 5px;
+}
+
+.favorite-item select {
+    margin-left: auto;
+}
+
+.chain-title {
+    font-style: italic;
+    margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- integrate search bar for cryptocurrencies
- allow creating folders and moving favorites
- show token logo and current price grouped by chain
- update docs with new workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eb67acc8c83238cbf6a83044ffa4a