### PR TITLE
Fix crash in watch list grouping

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,9 +184,6 @@ function loadWatchList() {
         folderDiv.appendChild(title);
 
         const chainMap = {};
-        folder.coins.forEach(id => {
-            chainMap[id] = null; // placeholder
-        });
 
         Promise.all(folder.coins.map(id => fetch(`https://api.coingecko.com/api/v3/coins/${id}`)
             .then(r => r.json())


### PR DESCRIPTION
## Summary
- remove unused placeholder creation in `loadWatchList`
- keep watch list grouping map clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec45e80608323a8fd05307384b752